### PR TITLE
🔨 chore: update trigger workflow in other repository step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,7 @@ jobs:
       - run: docker compose -f docker-compose.ci.yml config
         env:
           DOCKERHUB_USERNAME: DOCKERHUB_USERNAME
+
+  trigger_create_deployment:
+    uses: ./github/workflows/create-deployment.yml
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,3 @@ jobs:
       - run: docker compose -f docker-compose.ci.yml config
         env:
           DOCKERHUB_USERNAME: DOCKERHUB_USERNAME
-
-  trigger_create_deployment:
-    uses: ./github/workflows/create-deployment.yml@d10cad59435cf7928d1b379958f212ecbc78df48
-    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,5 @@ jobs:
           DOCKERHUB_USERNAME: DOCKERHUB_USERNAME
 
   trigger_create_deployment:
-    uses: ./github/workflows/create-deployment.yml
+    uses: ./github/workflows/create-deployment.yml@d10cad59435cf7928d1b379958f212ecbc78df48
     secrets: inherit

--- a/.github/workflows/create-deployment.yml
+++ b/.github/workflows/create-deployment.yml
@@ -9,45 +9,14 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger workflow in other repository
-        uses: actions/github-script@v6
+      - uses: actions/github-script@v6
         with:
           script: |
-            const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
-
-            try {
-              await github.rest.repos.createDispatchEvent({
-                owner: '${{ github.repository_owner }}',
-                repo: 'chat-deployment',
-                event_type: 'deploy',
-              });
-
-              let runStatus = 'queued';
-              let runConclusion;
-
-              while (runStatus !== 'completed') {
-                const runs = await github.rest.actions.listWorkflowRunsForRepo({
-                  owner: '${{ github.repository_owner }}',
-                  repo: 'chat-deployment',
-                  event: 'repository_dispatch',
-                  per_page: 1,
-                });
-
-                runStatus = runs.data.workflow_runs[0].status;
-                console.log(`Workflow run status: ${runStatus}`);
-
-                if (runStatus !== 'completed') {
-                  await sleep(5000); // wait for 5 seconds before checking the status again
-                } else {
-                  runConclusion = runs.data.workflow_runs[0].conclusion;
-                }
-              }
-
-              if (runConclusion !== 'success') {
-                throw new Error(`Workflow did not end in success. Conclusion: ${runConclusion}`);
-              }
-            } catch (error) {
-              console.error('Error:', error);
-            }
+            const result = await github.rest.repos.createDispatchEvent({
+              owner: '${{ github.repository_owner }}',
+              repo: 'chat-deployment',
+              event_type: 'deploy',
+            });
+            console.log(`Target Job URL: ${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${result.data.id}`);
 
           github-token: ${{ secrets.DISPATCH_PAT }}

--- a/.github/workflows/create-deployment.yml
+++ b/.github/workflows/create-deployment.yml
@@ -17,6 +17,6 @@ jobs:
               repo: 'chat-deployment',
               event_type: 'deploy',
             });
-            console.log(`Target Job URL: ${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${result.data.id}`);
+            console.log(`Target Job URL: ${process.env.GITHUB_SERVER_URL}/${{ github.repository_owner }}/chat-deployment/actions/runs/${result.data.id}`);
 
           github-token: ${{ secrets.DISPATCH_PAT }}


### PR DESCRIPTION
- Simplify the trigger workflow step by removing unnecessary code and using the `with` block directly.
- Update the console log message to include the target job URL for better visibility.