### PR TITLE
🔧 fix: update nginx configuration to proxy pass correctly to backend server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     ports:
-      - 80:80
+      - 8080:80
     command: [nginx-debug, '-g', 'daemon off;']
 
 volumes:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -6,8 +6,12 @@ http {
     }
     server {
         listen 80;
-        location /api {
-            proxy_pass http://backend;
+        location /api/ {
+            proxy_pass http://backend/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
 }


### PR DESCRIPTION
- Update the `location /api` block in the nginx configuration to include a trailing slash in the `proxy_pass` directive.
- Add proxy headers to preserve the original client IP and protocol information.
- Update the port mapping in the Docker Compose file to use port 8080 instead of 80 for the host.

These changes ensure that requests to `/api` are correctly forwarded to the backend server and that the client IP and protocol information are preserved.