### PR TITLE
🔨 chore: update deployment workflow to clone repository and target specific directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,3 @@ jobs:
       - run: docker compose -f docker-compose.ci.yml config
         env:
           DOCKERHUB_USERNAME: DOCKERHUB_USERNAME
-
-  trigger_create_deployment:
-    uses: ./.github/workflows/create-deployment.yml
-    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,14 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.VM_HOST }}
+          username: ${{ secrets.VM_USERNAME }}
+          key: ${{ secrets.VM_PRIVATE_KEY }}
+          script: |
+            rm-rf ${{ github.event.repository.name }}
+            git clone --depth 1 https://github.com/${{ github.repository }}.git
       - run: |
           echo DATABASE_URL=$DATABASE_URL >> .env.backend
           echo JWT_SECRET=$JWT_SECRET  >> .env.backend
@@ -26,12 +33,14 @@ jobs:
           host: ${{ secrets.VM_HOST }}
           username: ${{ secrets.VM_USERNAME }}
           key: ${{ secrets.VM_PRIVATE_KEY }}
-          source: docker-compose.yml,.env.backend,.env.test,nginx
-          target: /${{ secrets.VM_USERNAME }}
+          source: .env.backend
+          target: /${{ secrets.VM_USERNAME }}/${{ github.event.repository.name }}
           timeout: 120s
       - uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.VM_HOST }}
           username: ${{ secrets.VM_USERNAME }}
           key: ${{ secrets.VM_PRIVATE_KEY }}
-          script: docker compose up -d --force-recreate
+          script: |
+            cd ${{ github.event.repository.name }}
+            docker compose up -d --force-recreate


### PR DESCRIPTION
The deployment workflow has been updated to use the `appleboy/ssh-action` action to clone the repository and target a specific directory on the VM. This allows for better organization and management of the deployed code. Additionally, the script for starting the Docker containers has been updated to change to the repository directory before running the command.